### PR TITLE
remove pwned file in case it already exists

### DIFF
--- a/exploit_defaults_mailer.py
+++ b/exploit_defaults_mailer.py
@@ -361,6 +361,10 @@ def run_until_success(argv, env):
 	#null_fd = os.open('/dev/null', os.O_RDWR)
 	#os.dup2(null_fd, 2)
 
+	# remove the pwned file if exists
+	if os.path.exists(PWNED_PATH):
+		os.remove(PWNED_PATH)
+
 	for i in range(65536):
 		sys.stdout.write('%d\r' % i)
 		if i % 8 == 0:


### PR DESCRIPTION
Hello,
this pull requests makes sure the pwned file does not exist prior exploitation. 

I've just experienced one case like that, and obviously the condition `os.stat(PWNED_PATH).st_uid != 0` gave a false positive.